### PR TITLE
Fixed hex colours and made rainbow/flashing buttons toggleable in config

### DIFF
--- a/src/main/java/hhitt/fancyglow/inventory/CreatingInventory.java
+++ b/src/main/java/hhitt/fancyglow/inventory/CreatingInventory.java
@@ -105,6 +105,10 @@ public class CreatingInventory implements InventoryHolder {
     private void setFlashingItem(final Player player) {
         // Clear flashing item since plugin no longer
         int slot = config.getInt("Inventory.Flashing.Slot", 40);
+        if (slot == -1) {
+            return;
+        }
+
         inventory.setItem(slot, null);
 
         // Returns if player doesn't have any team or isn't glowing.
@@ -123,6 +127,11 @@ public class CreatingInventory implements InventoryHolder {
     }
 
     private void setRainbowItem() {
+        int slot = config.getInt("Inventory.Rainbow.Slot", 39);
+        if (slot == -1) {
+            return;
+        }
+
         // Rainbow head
         ItemStack rainbowHead = HeadUtils.getCustomSkull(config.getString("Inventory.Rainbow.Texture", DEFAULT_RAINBOW_TEXTURE));
         ItemMeta rainbowHeadMeta = rainbowHead.getItemMeta();
@@ -132,7 +141,7 @@ public class CreatingInventory implements InventoryHolder {
         rainbowHeadMeta.setLore(messageHandler.getMessages(Messages.RAINBOW_HEAD_LORE));
         rainbowHead.setItemMeta(rainbowHeadMeta);
 
-        inventory.setItem(config.getInt("Inventory.Rainbow.Slot", 39), rainbowHead);
+        inventory.setItem(slot, rainbowHead);
     }
 
     private void setPlayerStatusItem(Player player) {

--- a/src/main/java/hhitt/fancyglow/utils/MessageUtils.java
+++ b/src/main/java/hhitt/fancyglow/utils/MessageUtils.java
@@ -11,7 +11,11 @@ public class MessageUtils {
 
     private static BukkitAudiences adventure;
     private static final MiniMessage MINI_MESSAGE = MiniMessage.miniMessage();
-    private static final LegacyComponentSerializer LEGACY_COMPONENT_SERIALIZER = LegacyComponentSerializer.legacySection();
+    private static final LegacyComponentSerializer LEGACY_COMPONENT_SERIALIZER = LegacyComponentSerializer.builder()
+        .character('§')
+        .hexColors()
+        .useUnusualXRepeatedCharacterHexFormat()
+        .build();
 
     /**
      * Parses a message with the mini message format


### PR DESCRIPTION
I was unable to get hex colours working with the current setup but have adjusted the LegacyComponentSerializer to resolve this. I have also added the possibility of setting `Slot` to `-1` in the rainbow and flashing configs to hide them from the gui, this is useful for servers that do not want to use those features at all. 