### PR TITLE
fix: IllegalStateException error when removing player from color teams

### DIFF
--- a/src/main/java/hhitt/fancyglow/managers/GlowManager.java
+++ b/src/main/java/hhitt/fancyglow/managers/GlowManager.java
@@ -137,7 +137,8 @@ public class GlowManager {
         Team team;
         for (final ChatColor color : COLORS_ARRAY) {
             team = board.getTeam(color.name());
-            if (team != null) {
+            // fix #31: ISE (IllegalStateException) due to entry removal when team does not have it.
+            if ((team != null) && team.hasEntry(cleanName)) {
                 team.removeEntry(cleanName);
             }
         }


### PR DESCRIPTION
This PR implements changes to solve the error mentioned on Issue #31 that occurs when the plugin calls to `removePlayerFromAllTeams` (most-probable root cause) and it does not ensure the player is in that specific team, which causes an `IllegalStateException`.

As this error occurs in specific-moments (and maybe with specific players amount) I was unable to recreate the error, but following the code flow in the [log](https://mclo.gs/sfYPb8K) it appears to come from the `GlowManager#removePlayerFromAllTeams` method line `:140` due to a non "safe" deletion of the team's entry, with the proposed changes the error should not keep happen.
